### PR TITLE
Don't allow repeated roles and some database location changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codify"
-version = "0.5.0-beta"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codify"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -20,7 +20,6 @@ pub struct Database {
 }
 
 impl Database {
-    #[tracing::instrument]
     pub async fn init_from_directory(directory: &str) -> anyhow::Result<Self> {
         if !Path::new(directory).exists() {
             debug!("Target directory doesn't exists. So creating it.");
@@ -29,9 +28,9 @@ impl Database {
                 .context("Failed to create directory for database")?;
         }
 
-        info!("Loading autoRulesMessages.ron");
+        info!("Loading role_selection.ron");
         let auto_rules_messages =
-            FileDatabase::load_from_path_or_default(format!("{directory}/autoRulesMessages.ron"))
+            FileDatabase::load_from_path_or_default(format!("{directory}/role_selection.ron"))
                 .context("Failed to open user store file")?;
 
         Ok(Self {


### PR DESCRIPTION
- feat(/servidor): don't allow repeated roles in categories
- version: bump to 0.6.0
- database: use `role_selection.ron` instead of `autoRuleMessages.ron`
